### PR TITLE
Quick fix middleware

### DIFF
--- a/authization-module/common/middleware/setup-middleware.js
+++ b/authization-module/common/middleware/setup-middleware.js
@@ -16,6 +16,6 @@ module.exports = function (app, session) {
     app.use(passport.session());
 
     //Interceptor that checks for authorization
-    app.use((req, res, next) => req.path.includes('api') ? authorization.check(req, res, next) : next());
+    app.use((req, res, next) => req.path.includes('/api/') ? authorization.check(req, res, next) : next());
 
 };


### PR DESCRIPTION
 Fixed middleware setup to check authorization ONLY on "/api/" instead of anything that contained the string "api"